### PR TITLE
run compat-helper on pull request

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,6 +3,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '00 00 * * *'
+  pull-request
 
 jobs:
   CompatHelper:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,7 +3,7 @@ name: CompatHelper
 on:
   schedule:
     - cron: '00 00 * * *'
-  pull-request
+  pull_request
 
 jobs:
   CompatHelper:

--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -3,8 +3,9 @@ name: CompatHelper
 on:
   schedule:
     - cron: '00 00 * * *'
-  pull_request
-
+  pull_request:
+    branches:
+      - master
 jobs:
   CompatHelper:
     runs-on: ubuntu-latest


### PR DESCRIPTION
This should help avoid forgetting upper bounds on `compat` entries, which can then block automerge in the Julia Registry.