### PR TITLE
Compatibility bumps

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "JellyMe4"
 uuid = "19ac8677-9a15-4623-9afd-84acc6165ce7"
 authors = ["Phillip Alday <me@phillipalday.com>"]
-version = "0.2.0"
+version = "0.2.1"
 
 [deps]
 CategoricalArrays = "324d7699-5711-5eae-9e2f-1d82baa6b597"
@@ -20,7 +20,7 @@ CategoricalArrays = "0.7, 0.8"
 DataFrames = "0.20, 0.21"
 Distributions = "0.20, 0.22, 0.23, 0.24"
 GLM = "1.3"
-MixedModels = "2.2, 2.3, 3.0"
+MixedModels = "2.2, 2.3, 2.4, 3.0"
 RCall = "0.13"
 StatsBase = "0.31, 0.32, 0.33"
 StatsModels = "0.6.8"


### PR DESCRIPTION
There is a known incompatibility between the tests and MixedModels 3.0 (since the tests still pull in data from Feather, which is incompatible with the new Arrow format for MixedModels 3.0). That will be changed later today. Tests pass locally.

Closes #35